### PR TITLE
optimize: Image Transformations使用量を削減

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,9 +3,9 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
 	images: {
 		formats: ["image/webp", "image/avif"],
-		deviceSizes: [640, 750, 828, 1080, 1200, 1920], // 不要な大サイズを削除
-		imageSizes: [16, 32, 48, 64, 96, 128, 256], // ポケモン画像に適したサイズに最適化
-		minimumCacheTTL: 2678400, // 31日間 (Next.js公式推奨値)
+		deviceSizes: [640, 750, 828, 1080, 1200], // モバイル・タブレット中心に削減
+		imageSizes: [32, 64, 96, 128, 256], // 小さいサイズを削減してポケモン画像に最適化
+		minimumCacheTTL: 31536000, // 1年間 (より長いキャッシュでtransformation回数削減)
 		localPatterns: [
 			{
 				pathname: "/**",

--- a/src/app/(list)/table/page.tsx
+++ b/src/app/(list)/table/page.tsx
@@ -32,6 +32,7 @@ export default async function Table() {
 												alt={type}
 												width={32}
 												height={32}
+												unoptimized
 												className={"size-6 rounded-full"}
 											/>
 										);

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -14,7 +14,7 @@ export async function Header() {
 			<div className="flex items-center">
 				<Link href={"/"} className="flex items-center gap-2">
 					<div className="overflow-hidden rounded-md">
-						<Image src={"/icon.jpg"} alt={"icon"} width={28} height={28} />
+						<Image src={"/icon.jpg"} alt={"icon"} width={28} height={28} unoptimized />
 					</div>
 					<span className="font-extrabold">{config.title}</span>
 				</Link>

--- a/src/components/layout/pokemon-type-filter.tsx
+++ b/src/components/layout/pokemon-type-filter.tsx
@@ -53,6 +53,7 @@ export function PokemonTypeFilter({
 									alt={option.label}
 									width={32}
 									height={32}
+									unoptimized
 									className={`size-8 rounded-full ${
 										checked ? "opacity-100" : "opacity-30"
 									}`}

--- a/src/components/pokemon/image-card.tsx
+++ b/src/components/pokemon/image-card.tsx
@@ -77,6 +77,7 @@ export const ImageCard = ({
 					fill
 					priority={priority}
 					loading={priority ? undefined : "lazy"}
+					quality={80}
 					sizes="(max-width: 768px) 25vw, (max-width: 1200px) 20vw, 128px"
 					className={cn("object-contain transition-opacity duration-300", {
 						"opacity-0": loadState !== "loaded",


### PR DESCRIPTION
- 小さなアイコン(タイプ・サイト)にunoptimizedプロパティを追加
- Next.js画像設定を最適化してtransformation回数を削減
- ポケモン画像のqualityを80に調整して処理負荷軽減
- minimumCacheTTLを1年に延長してre-transformation頻度を削減